### PR TITLE
Fix season 19 startDate

### DIFF
--- a/seasons.json
+++ b/seasons.json
@@ -192,7 +192,7 @@
       {
         "id": "division.bro.official.pc-2018-19",
         "attributes": {
-          "startDate": "06-10-2022",
+          "startDate": "08-10-2022",
           "endDate": "00-00-0000"
         }
       }


### PR DESCRIPTION
season 19 start date seems to be a typo, it started today (08-10-2022).

https://github.com/pubg/api-assets/blob/2b3933292c6be8f4d3751c5116d45cbb5b179bc3/seasons.json#L195
